### PR TITLE
Adding pprint.dims() and pprint.info()

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -112,7 +112,7 @@ end
 
 
 function Printer:new(v, depth)
-   local p = self.init(depth)
+   local p = self:init(depth)
    return p:put_value(v)
 end
 


### PR DESCRIPTION
Adding pprint.dims() and pprint.info() that return inline strings describing a tensor's dimensions and more complete info (dims, min, mean, max, type).

e.g.:
a=torch.FloatTensor(1,2,3)
print(pprint.dims(a))
print(pprint.info(a))

will print:

1x2x3
[1x2x3, min: 0, mean: 1.2856009280022e+31, max: 7.7135212106908e+31, type: "torch.FloatTensor"]
