### PR TITLE
Print correct type when printing large tensor

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -206,7 +206,7 @@ function Printer:put_tensor(t)
     if t:nElement() <= 20 then
         self:puts(tostring(t))
     else
-        self:puts('[torch.Tensor of dimension ')
+        self:puts('[' .. torch.typename(t) .. ' of dimension ')
         self:put_tensor_dims(t)
         self:puts(']')
     end


### PR DESCRIPTION
Before this PR, when using pprint to show a large tensor, it always says "torch.Tensor", regardless of its type. For example:

```lua
pprint(torch.FloatTensor(5000000))
pprint(torch.ByteTensor(5000000))
pprint(torch.LongTensor(5000000))
```

will all print

```
[torch.Tensor of dimension 5000000]
```
ie not showing their true type.

Now it will print their proper type:

```
[torch.FloatTensor of dimension 5000000]
[torch.ByteTensor of dimension 5000000]
[torch.LongTensor of dimension 5000000]
````